### PR TITLE
Add --capture-ratio and --stats-only CLI args

### DIFF
--- a/sim.py
+++ b/sim.py
@@ -230,16 +230,17 @@ def main(argv: List[str]) -> int:
 
 
     # we're done, print some stuff
-    frame_detail_print("===== PRESENTED FRAMES =====")
-    for frame in presented_framelist:
-        if frame.disposition == Disp.COMPOSITED:
-            dispstr = f"CAPTURED + COMPOSITED @ otime {frame.composite_t_ms:0.3f}ms"
-            # composited_framelist.append(frame)
-        elif frame.disposition == Disp.COMPOSITED_DUP:
-            dispstr = f"CAPTURED + COMPOSITED (DUPS) @ otime {frame.composite_t_ms:0.3f}ms"
-        else:
-            dispstr = frame.disposition.name
-        frame_detail_print(f"pframe {frame.present_frame} @ {frame.present_t_ms:0.3f}ms, {dispstr}")
+    if not args.stats_only:
+        print("===== PRESENTED FRAMES =====")
+        for frame in presented_framelist:
+            if frame.disposition == Disp.COMPOSITED:
+                dispstr = f"CAPTURED + COMPOSITED @ otime {frame.composite_t_ms:0.3f}ms"
+                # composited_framelist.append(frame)
+            elif frame.disposition == Disp.COMPOSITED_DUP:
+                dispstr = f"CAPTURED + COMPOSITED (DUPS) @ otime {frame.composite_t_ms:0.3f}ms"
+            else:
+                dispstr = frame.disposition.name
+            print(f"pframe {frame.present_frame} @ {frame.present_t_ms:0.3f}ms, {dispstr}")
 
     frame_detail_print("\n\n===== OUTPUT/COMPOSITED FRAMES =====")
     prev_present_frame = 0

--- a/sim.py
+++ b/sim.py
@@ -174,7 +174,7 @@ def parse_args(args: List[str]) -> argparse.Namespace:
     parser.add_argument(
         "--capture-ratio", "--cr",
         type=float,
-        default=None,
+        default=2,
         help="capture no more than [this ratio] * [OBS FPS] times per second, loosely speaking (set to 0 for no limit)",
     )
 
@@ -198,9 +198,7 @@ def main(argv: List[str]) -> int:
     last_captured: Optional[GameFrame] = None
 
     obs = OBS(OBS_FPS)
-    if args.capture_ratio is None:
-        gc = GameCapture(obs.composite_interval_ms / 2)
-    elif args.capture_ratio == 0:
+    if args.capture_ratio == 0:
         gc = GameCapture(0)
     else:
         gc = GameCapture(obs.composite_interval_ms / args.capture_ratio)

--- a/sim.py
+++ b/sim.py
@@ -171,8 +171,14 @@ def parse_args(args: List[str]) -> argparse.Namespace:
         help="use specified PresentMon capture file as pframe source",
     )
 
-    return parser.parse_args(args)
+    parser.add_argument(
+        "--capture-ratio", "--cr",
+        type=float,
+        default=None,
+        help="capture no more than [this ratio] * [OBS FPS] times per second, loosely speaking (set to 0 for no limit)",
+    )
 
+    return parser.parse_args(args)
 
 def main(argv: List[str]) -> int:
     args = parse_args(argv)
@@ -185,7 +191,12 @@ def main(argv: List[str]) -> int:
     last_captured: Optional[GameFrame] = None
 
     obs = OBS(OBS_FPS)
-    gc = GameCapture(obs.composite_interval_ms / 2)
+    if args.capture_ratio is None:
+        gc = GameCapture(obs.composite_interval_ms / 2)
+    elif args.capture_ratio == 0:
+        gc = GameCapture(0)
+    else:
+        gc = GameCapture(obs.composite_interval_ms / args.capture_ratio)
 
     print(f"Data from: '{args.presentmon_file}'\nComposite rate {OBS_FPS}fps\n")
 

--- a/sim.py
+++ b/sim.py
@@ -178,6 +178,13 @@ def parse_args(args: List[str]) -> argparse.Namespace:
         help="capture no more than [this ratio] * [OBS FPS] times per second, loosely speaking (set to 0 for no limit)",
     )
 
+    parser.add_argument(
+        "--stats-only", "--silent", "-s",
+        default=False,
+        action="store_true",
+        help="print only the statistics, not the presented or captured frame info",
+    )
+
     return parser.parse_args(args)
 
 def main(argv: List[str]) -> int:
@@ -218,8 +225,14 @@ def main(argv: List[str]) -> int:
 
         presented_framelist.append(frame)
 
+    # Don't print frame details in stats-only/silent mode
+    def frame_detail_print(*fargs):
+        if not args.stats_only:
+            print(*fargs)
+
+
     # we're done, print some stuff
-    print("===== PRESENTED FRAMES =====")
+    frame_detail_print("===== PRESENTED FRAMES =====")
     for frame in presented_framelist:
         if frame.disposition == Disp.COMPOSITED:
             dispstr = f"CAPTURED + COMPOSITED @ otime {frame.composite_t_ms:0.3f}ms"
@@ -228,9 +241,9 @@ def main(argv: List[str]) -> int:
             dispstr = f"CAPTURED + COMPOSITED (DUPS) @ otime {frame.composite_t_ms:0.3f}ms"
         else:
             dispstr = frame.disposition.name
-        print(f"pframe {frame.present_frame} @ {frame.present_t_ms:0.3f}ms, {dispstr}")
+        frame_detail_print(f"pframe {frame.present_frame} @ {frame.present_t_ms:0.3f}ms, {dispstr}")
 
-    print("\n\n===== OUTPUT/COMPOSITED FRAMES =====")
+    frame_detail_print("\n\n===== OUTPUT/COMPOSITED FRAMES =====")
     prev_present_frame = 0
     prev_present_time = 0.0
     gaplist_frames = []
@@ -247,7 +260,7 @@ def main(argv: List[str]) -> int:
 
         dupstr = " DUP" if frame.disposition == Disp.COMPOSITED_DUP else ""
 
-        print(f"oframe {frame.composite_frame} @ {frame.composite_t_ms:0.3f}ms, pframe {frame.present_frame} @ {frame.present_t_ms:0.3f}ms, gap {frame_gap} frames, {time_gap:0.3f}ms{dupstr}")
+        frame_detail_print(f"oframe {frame.composite_frame} @ {frame.composite_t_ms:0.3f}ms, pframe {frame.present_frame} @ {frame.present_t_ms:0.3f}ms, gap {frame_gap} frames, {time_gap:0.3f}ms{dupstr}")
 
     print("\n\n===== STATS =====")
     print(f"Presented frames: {len(presented_framelist)}")


### PR DESCRIPTION
Adds some more (optional) CLI args that can be used, `--capture-ratio` and `--stats-only`:

```
% python3 ./sim.py --help
usage: sim.py [-h] [--presentmon-file PRESENTMON_FILE] [--capture-ratio CAPTURE_RATIO] [--stats-only]

Simulate OBS capture & compositing

options:
  -h, --help            show this help message and exit
  --presentmon-file PRESENTMON_FILE, --pmf PRESENTMON_FILE
                        use specified PresentMon capture file as pframe source
  --capture-ratio CAPTURE_RATIO, --cr CAPTURE_RATIO
                        capture no more than [this ratio] * [OBS FPS] times per second, loosely speaking (set to 0 for no limit)
  --stats-only, --silent, -s
                        print only the statistics, not the presented or captured frame info
```

---

`--stats-only` output currently looks like this:

```
% python3 ./sim.py --pmf ~/Downloads/pmcaps-TR/PresentMon-TR-Ultra-Uncapped-Gameplay-100-120FPS-ish-2024-01-30T170850.csv -s              
Data from: '/Users/user/Downloads/pmcaps-TR/PresentMon-TR-Ultra-Uncapped-Gameplay-100-120FPS-ish-2024-01-30T170850.csv'
Composite rate 60.0fps



===== STATS =====
Presented frames: 13982
Captured frames: 13605 (6406 unused)
Composited/output frames: 7199

Frame number gaps: 2.00 avg, 0 min, 4 max, 0.43 stddev
Frame time gaps: 17.255 avg, 5.610 min, 33.164 max, 3.294 stddev

```

---

I think the `--capture-ratio` is the more useful one, since one can always do `sim.py | grep stddev` to just grab the stats...

But offering them both, since I had them locally.

Open to requests for changes, review feedback, or feel free to edit the branch directly or land the changes however you like, of course. (If wanting these changes in the first place!)